### PR TITLE
Fix shebang expression in some examples

### DIFF
--- a/CLASE-2/00_tutorial_bash/demo19.select
+++ b/CLASE-2/00_tutorial_bash/demo19.select
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #Ejemplo : uso de la construcción select
 
 opciones="Entrar Salir"

--- a/CLASE-2/00_tutorial_bash/demo20.case
+++ b/CLASE-2/00_tutorial_bash/demo20.case
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #Ejemplo : uso de la construcción case
 
 while [ 1 ]; do


### PR DESCRIPTION
Hello! 😄  , in some examples the shebang seems to be incorrectly written and according to [Introducción al scripting](https://github.com/roxsross/The-DevOps-Journey-101/blob/master/CLASE-2/02-trabajando-con-la-cli/02-introduccion-scripting.md) we must take it into account so that it uses the interpreter that we define.

Thanks!